### PR TITLE
rol="img" => role="img"

### DIFF
--- a/src/pages/Thanks.js
+++ b/src/pages/Thanks.js
@@ -10,7 +10,7 @@ export default function thanks() {
       <Purchase>
         <h2>
           Sucessful purchase
-          <span rol="img" aria-label="emoji">
+          <span role="img" aria-label="emoji">
             💚
           </span>
         </h2>


### PR DESCRIPTION
warning  Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji

This change will help to avoid any errors in the console